### PR TITLE
Fix bug 36 rendering issue

### DIFF
--- a/src/Vtk/Viewer/quickVtkFboRenderer.cpp
+++ b/src/Vtk/Viewer/quickVtkFboRenderer.cpp
@@ -49,10 +49,12 @@ namespace quick {
         }
 
         auto FboRenderer::render() -> void {
+            m_interactor->Disable();
             m_fboOffscreenWindow->PushState();
             m_fboOffscreenWindow->OpenGLInitState();
             m_fboOffscreenWindow->InternalRender();
             m_fboOffscreenWindow->PopState();
+            m_interactor->Enable();
         }
 
         auto FboRenderer::createFramebufferObject(const QSize &size) -> QOpenGLFramebufferObject* {


### PR DESCRIPTION
Hi there,
I would like to use your VTK-QtQuick integration in a project, but I was having issues when building against VTK 8.2.0. 

ISSUE 1
As mentioned by others, the rendering resulted in a 1x1 white pixel. I can confirm that this issue happens only with VTK 8.2.0, with version 8.0.1 or 8.1.2 the rendering works perfectly fine.  

FYI: I am using Qt 5.10.0, at the moment can't test with your preferred version 5.12.1.

I figured the issue is caused by an inconsistent OpenGL state: The QtQuick side of things modify the GL context directly, which is then not synchronized correctly with the VTK OpenGL context.

I made some changes which circumvent this issue so I can get the app to render without any GL or VTK errors reported.

There is one line I'm totally puzzled about though:
  this->State->Initialize(this);

If you figure out why is this necessary, or if you have a better suggestion please let me know :)

ISSUE 2
There was another rendering related issue which I fixed: The interactor often interrupted the rendering process which caused really strange outcome, the model "jumping around" or being re-scaled at random. 

By disabling the interactor for the duration of the rendering I get smooth and problem free renderings.
