### PR TITLE
Fix build error for api generator on windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 /doc/doxygen/output/
 .idea
 *.pyc
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,11 @@ set (QUICKVTK_CORE_NAME "${PROJECT_NAME}Core")
 add_library (${QUICKVTK_CORE_NAME} SHARED ${list_core_src} ${list_core_hdr})
 set_target_properties(${QUICKVTK_CORE_NAME} PROPERTIES PUBLIC_HEADER "${list_core_hdr}")
 
+# Export symbols for DLL on windows
+if(MSVC)
+target_compile_definitions(${QUICKVTK_CORE_NAME} PRIVATE QuickVtkCore_EXPORTS)
+endif()
+
 set(LINK_LIBRARIES PUBLIC ${VTK_LIBRARIES} PUBLIC Qt5::Core PUBLIC Qt5::Widgets PUBLIC Qt5::Gui PUBLIC Qt5::Quick PUBLIC Qt5::Qml PUBLIC Qt5::Concurrent)
 if(UNIX AND NOT APPLE)
     set(LINK_LIBRARIES ${LINK_LIBRARIES} PUBLIC Qt5::X11Extras)

--- a/src/Core/TypeInfo/quickTypeInfoList.hpp
+++ b/src/Core/TypeInfo/quickTypeInfoList.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "quickQmlRegister.hpp"
+#include "quickExport.h"
 
 #include <QAbstractListModel>
 
@@ -10,7 +11,7 @@ namespace quick {
 
         class Symbol;
 
-        class List : public QAbstractListModel {
+        class QUICKVTKCORE_API List : public QAbstractListModel {
             Q_OBJECT
             Q_PROPERTY(bool visible READ isVisible WRITE setVisible NOTIFY visibleChanged);
             Q_PROPERTY(QString filter READ getFilter WRITE setFilter NOTIFY filterChanged);

--- a/src/Core/Utils/quickExport.h
+++ b/src/Core/Utils/quickExport.h
@@ -1,0 +1,21 @@
+#pragma once
+
+/**
+ * @file quickExport.h
+ * @brief export attributes for windows shared library(.DLL)
+ * @version 0.1
+ * @date 2019-12-22
+ * 
+ */
+
+#ifdef _WIN32
+#ifdef QuickVtkCore_EXPORTS
+/* We are building this library */
+#define QUICKVTKCORE_API __declspec(dllexport)
+#else
+/* We are using this library */
+#define QUICKVTKCORE_API __declspec(dllimport)
+#endif
+#else
+#define QUICKVTKCORE_API
+#endif


### PR DESCRIPTION
fix build error for api generator on windows:
```
APIGenerator.cpp.obj : error LNK2001: unresolved external symbol "public: static class QMap<class QString,class quick::TypeInfo::Enum *> quick::TypeInfo::List::EnumLookup" (?EnumLookup@List@TypeInfo@quick@@2V?$QMap@VQString@@PEAVEnum@TypeInfo@quick@@@@A)
build\API-Docs.exe : fatal error LNK1120: 1 unresolved externals`
```